### PR TITLE
[feat] 플레이스뷰 셀 선택 시 segue 연결 자연스럽게 수정

### DIFF
--- a/Foodle/Foodle.xcodeproj/project.pbxproj
+++ b/Foodle/Foodle.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4B1122392BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1122382BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift */; };
 		4B1122402BE351D200A2E577 /* ResultTableViewcell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B11223F2BE351D200A2E577 /* ResultTableViewcell.swift */; };
 		4B1261372BA31450002F52BD /* UpcomingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1261362BA31450002F52BD /* UpcomingCollectionViewCell.swift */; };
+		4B23DBDF2BFEF09600E5E4FD /* MyPlaceTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B23DBDE2BFEF09600E5E4FD /* MyPlaceTableViewController.swift */; };
 		4B5D9B6D2BBE3FFB00F1BD58 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D9B6C2BBE3FFB00F1BD58 /* SearchViewController.swift */; };
 		4B5D9B6F2BBE406400F1BD58 /* DetailPlaceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D9B6E2BBE406400F1BD58 /* DetailPlaceViewController.swift */; };
 		4B5D9B712BBE4CB200F1BD58 /* PlaceImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D9B702BBE4CB200F1BD58 /* PlaceImageCollectionViewCell.swift */; };
@@ -47,6 +48,7 @@
 		4B1122382BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableBottomSheetViewController.swift; sourceTree = "<group>"; };
 		4B11223F2BE351D200A2E577 /* ResultTableViewcell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTableViewcell.swift; sourceTree = "<group>"; };
 		4B1261362BA31450002F52BD /* UpcomingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingCollectionViewCell.swift; sourceTree = "<group>"; };
+		4B23DBDE2BFEF09600E5E4FD /* MyPlaceTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPlaceTableViewController.swift; sourceTree = "<group>"; };
 		4B5D9B6C2BBE3FFB00F1BD58 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		4B5D9B6E2BBE406400F1BD58 /* DetailPlaceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPlaceViewController.swift; sourceTree = "<group>"; };
 		4B5D9B702BBE4CB200F1BD58 /* PlaceImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceImageCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 				4B1122382BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift */,
 				4B70D9BC2BF5AF4D00F3C965 /* MyPlaceViewController.swift */,
 				4B70D9C42BF5BC1800F3C965 /* MyPlaceScrollableViewController.swift */,
+				4B23DBDE2BFEF09600E5E4FD /* MyPlaceTableViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -282,6 +285,7 @@
 				4BA12D7F2BA004CE00BC4EB0 /* AppDelegate.swift in Sources */,
 				4B73950E2BAC31A4006843DB /* SetMeetingViewController.swift in Sources */,
 				92B688482BB0A20400D7DF2C /* LoginViewCell.swift in Sources */,
+				4B23DBDF2BFEF09600E5E4FD /* MyPlaceTableViewController.swift in Sources */,
 				4BA12D812BA004CE00BC4EB0 /* SceneDelegate.swift in Sources */,
 				4B1122392BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift in Sources */,
 				4B7395102BAC31BB006843DB /* AddMeetingPlaceViewController.swift in Sources */,

--- a/Foodle/Foodle/AppDelegate.swift
+++ b/Foodle/Foodle/AppDelegate.swift
@@ -15,6 +15,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        if #available(iOS 15, *) {
+                    let appearance = UITabBarAppearance()
+                    let tabBar = UITabBar()
+                    appearance.configureWithOpaqueBackground()
+                    appearance.backgroundColor = UIColor.white
+                    tabBar.standardAppearance = appearance;
+                    UITabBar.appearance().scrollEdgeAppearance = appearance
+        }
         return true
     }
 

--- a/Foodle/Foodle/Base.lproj/Jinhee.storyboard
+++ b/Foodle/Foodle/Base.lproj/Jinhee.storyboard
@@ -895,7 +895,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="resultTableViewCell" rowHeight="170" id="C8N-C6-N1I" customClass="ResultTableViewcell" customModule="Foodle" customModuleProvider="target">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="resultTableViewCell" rowHeight="170" id="C8N-C6-N1I" customClass="ResultTableViewcell" customModule="Foodle" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="50" width="393" height="170"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="C8N-C6-N1I" id="bHf-qw-PcC">
@@ -1272,7 +1272,7 @@
                                         <rect key="frame" x="0.0" y="50" width="393" height="802"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <prototypes>
-                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MyPlaceTableViewCell" rowHeight="124" id="nVG-04-PVx" customClass="MyPlaceTableViewCell" customModule="Foodle" customModuleProvider="target">
+                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MyPlaceTableViewCell" rowHeight="124" id="nVG-04-PVx" customClass="MyPlaceTableViewCell" customModule="Foodle" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="50" width="393" height="124"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nVG-04-PVx" id="t9I-lH-vKJ">

--- a/Foodle/Foodle/Base.lproj/Jinhee.storyboard
+++ b/Foodle/Foodle/Base.lproj/Jinhee.storyboard
@@ -1327,6 +1327,7 @@
                     </view>
                     <connections>
                         <outlet property="headerView" destination="YoZ-pn-I6h" id="7yw-qH-dBh"/>
+                        <outlet property="stackView" destination="auK-bg-x2q" id="koH-hn-R4C"/>
                         <outlet property="tableView" destination="rPc-OL-Oel" id="LNc-dC-cyf"/>
                     </connections>
                 </viewController>

--- a/Foodle/Foodle/Base.lproj/Jinhee.storyboard
+++ b/Foodle/Foodle/Base.lproj/Jinhee.storyboard
@@ -886,6 +886,141 @@
             </objects>
             <point key="canvasLocation" x="7326" y="-2"/>
         </scene>
+        <!--My Place Table View Controller-->
+        <scene sceneID="kgz-ok-CYl">
+            <objects>
+                <tableViewController storyboardIdentifier="MyPlaceTableViewController" id="3Xj-1P-aCw" customClass="MyPlaceTableViewController" customModule="Foodle" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="zIG-HP-Kgp">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="resultTableViewCell" rowHeight="170" id="C8N-C6-N1I" customClass="ResultTableViewcell" customModule="Foodle" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="50" width="393" height="170"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="C8N-C6-N1I" id="bHf-qw-PcC">
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="170"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="opv-7l-Su0">
+                                            <rect key="frame" x="10" y="60" width="50" height="50"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="50" id="iIb-m6-bJG"/>
+                                                <constraint firstAttribute="width" constant="50" id="sRr-vI-96U"/>
+                                            </constraints>
+                                            <color key="tintColor" name="AccentColor"/>
+                                            <state key="normal" title="Button"/>
+                                            <buttonConfiguration key="configuration" style="plain" image="star" catalog="system"/>
+                                        </button>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dummy" translatesAutoresizingMaskIntoConstraints="NO" id="6Jp-r3-j60">
+                                            <rect key="frame" x="313" y="50" width="70" height="70"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="70" id="7cC-Fd-s1v"/>
+                                                <constraint firstAttribute="height" constant="70" id="qRv-D3-7th"/>
+                                            </constraints>
+                                        </imageView>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uvP-AN-05B">
+                                            <rect key="frame" x="65" y="30" width="238" height="110"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="라오빠빠" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="95n-yz-Cw1">
+                                                    <rect key="frame" x="0.0" y="0.0" width="72.666666666666671" height="25.333333333333332"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="200" id="Gvn-wZ-7KO"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" weight="black" pointSize="21"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="영업중" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9eu-F4-Xe0">
+                                                    <rect key="frame" x="0.0" y="30.333333333333336" width="44.333333333333336" height="20.333333333333336"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" name="AccentColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="920m" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mE6-Ce-aHk">
+                                                    <rect key="frame" x="0.0" y="89.666666666666671" width="45" height="20.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" text="서울특별시 송파구 오금동 ㅇㅇㅇ륭ㅇㅇ" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eso-W2-hee">
+                                                    <rect key="frame" x="96.666666666666643" y="69.333333333333329" width="141.33333333333337" height="40.666666666666671"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="42" id="79g-nF-YS0"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="카페" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HuM-jr-OvY">
+                                                    <rect key="frame" x="82.666666666666657" y="2.6666666666666643" width="29.666666666666671" height="20.333333333333332"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="휴일 토, 일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aa2-DF-clo">
+                                                    <rect key="frame" x="0.0" y="64.333333333333329" width="72.333333333333329" height="20.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstItem="aa2-DF-clo" firstAttribute="leading" secondItem="9eu-F4-Xe0" secondAttribute="leading" id="5k5-Jg-HyQ"/>
+                                                <constraint firstItem="95n-yz-Cw1" firstAttribute="leading" secondItem="uvP-AN-05B" secondAttribute="leading" id="BC5-0B-0pa"/>
+                                                <constraint firstItem="9eu-F4-Xe0" firstAttribute="top" secondItem="95n-yz-Cw1" secondAttribute="bottom" constant="5" id="Bgy-kH-6NK"/>
+                                                <constraint firstItem="HuM-jr-OvY" firstAttribute="centerY" secondItem="95n-yz-Cw1" secondAttribute="centerY" id="D1i-FG-P8P"/>
+                                                <constraint firstItem="Eso-W2-hee" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="mE6-Ce-aHk" secondAttribute="trailing" constant="10" id="ElA-ia-vqJ"/>
+                                                <constraint firstItem="mE6-Ce-aHk" firstAttribute="top" secondItem="aa2-DF-clo" secondAttribute="bottom" constant="5" id="K8R-Id-faM"/>
+                                                <constraint firstAttribute="bottom" secondItem="mE6-Ce-aHk" secondAttribute="bottom" id="MC5-3l-Kx6"/>
+                                                <constraint firstItem="9eu-F4-Xe0" firstAttribute="leading" secondItem="mE6-Ce-aHk" secondAttribute="leading" id="QzJ-kr-o8c"/>
+                                                <constraint firstItem="mE6-Ce-aHk" firstAttribute="baseline" secondItem="Eso-W2-hee" secondAttribute="baseline" id="eBq-Zk-IDC"/>
+                                                <constraint firstAttribute="trailing" secondItem="Eso-W2-hee" secondAttribute="trailing" id="f8b-D8-whp"/>
+                                                <constraint firstItem="95n-yz-Cw1" firstAttribute="top" secondItem="uvP-AN-05B" secondAttribute="top" id="q0T-fE-ErR"/>
+                                                <constraint firstItem="HuM-jr-OvY" firstAttribute="leading" secondItem="95n-yz-Cw1" secondAttribute="trailing" constant="10" id="qMw-pf-d5d"/>
+                                                <constraint firstAttribute="width" constant="360" id="sFl-pf-e9z"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="HuM-jr-OvY" secondAttribute="trailing" id="sd8-il-7be"/>
+                                                <constraint firstItem="mE6-Ce-aHk" firstAttribute="leading" secondItem="uvP-AN-05B" secondAttribute="leading" id="xuA-oK-Ol0"/>
+                                                <constraint firstItem="Eso-W2-hee" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="aa2-DF-clo" secondAttribute="trailing" constant="20" id="ynN-Rj-UTQ"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="uvP-AN-05B" secondAttribute="bottom" constant="30" id="1ou-Zn-e2R"/>
+                                        <constraint firstItem="opv-7l-Su0" firstAttribute="leading" secondItem="bHf-qw-PcC" secondAttribute="leading" constant="10" id="BlG-4C-8ya"/>
+                                        <constraint firstItem="uvP-AN-05B" firstAttribute="top" secondItem="bHf-qw-PcC" secondAttribute="top" constant="30" id="C5s-EA-Tom"/>
+                                        <constraint firstItem="uvP-AN-05B" firstAttribute="leading" secondItem="opv-7l-Su0" secondAttribute="trailing" constant="5" id="Dyq-Jf-26m"/>
+                                        <constraint firstAttribute="trailing" secondItem="6Jp-r3-j60" secondAttribute="trailing" constant="10" id="QT9-y2-vze"/>
+                                        <constraint firstItem="opv-7l-Su0" firstAttribute="centerY" secondItem="bHf-qw-PcC" secondAttribute="centerY" id="m24-0M-5MJ"/>
+                                        <constraint firstItem="6Jp-r3-j60" firstAttribute="leading" secondItem="uvP-AN-05B" secondAttribute="trailing" constant="10" id="qLG-4a-egZ"/>
+                                        <constraint firstItem="6Jp-r3-j60" firstAttribute="centerY" secondItem="bHf-qw-PcC" secondAttribute="centerY" id="xS2-e1-uAD"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="addressLabel" destination="Eso-W2-hee" id="0Sw-kO-kBc"/>
+                                    <outlet property="breakLabel" destination="aa2-DF-clo" id="JdB-8d-1so"/>
+                                    <outlet property="distanceLabel" destination="mE6-Ce-aHk" id="WuW-Zv-cxK"/>
+                                    <outlet property="isOpenLabel" destination="9eu-F4-Xe0" id="2Ov-vN-mTx"/>
+                                    <outlet property="placeCategoryLabel" destination="HuM-jr-OvY" id="3DT-7g-DrF"/>
+                                    <outlet property="placeImageView" destination="6Jp-r3-j60" id="Pef-Ll-sNr"/>
+                                    <outlet property="placeNameLabel" destination="95n-yz-Cw1" id="U5v-KJ-quG"/>
+                                    <outlet property="starButton" destination="opv-7l-Su0" id="47I-5M-WCn"/>
+                                    <segue destination="b3Z-rC-oH0" kind="show" id="Hyq-GP-qOp"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="3Xj-1P-aCw" id="kc3-cq-Oxj"/>
+                            <outlet property="delegate" destination="3Xj-1P-aCw" id="Ell-yv-qQj"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="6ZO-9Q-HhL"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FI6-vK-SRe" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4459" y="-696"/>
+        </scene>
         <!--LoginView-->
         <scene sceneID="iay-o0-Hqv">
             <objects>
@@ -923,11 +1058,11 @@
             <objects>
                 <viewController storyboardIdentifier="ScrollableBottomSheetViewController" id="9sO-5h-AcD" customClass="ScrollableBottomSheetViewController" customModule="Foodle" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="ccv-mc-LCA">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Vrr-Jv-MNr">
-                                <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BHm-aP-eWE">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="50"/>
@@ -954,7 +1089,7 @@
                                         </constraints>
                                     </view>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="N8X-HC-tqT">
-                                        <rect key="frame" x="0.0" y="50" width="393" height="792"/>
+                                        <rect key="frame" x="0.0" y="50" width="393" height="802"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <prototypes>
                                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="resultTableViewCell" rowHeight="170" id="2wc-2Z-Nef" customClass="ResultTableViewcell" customModule="Foodle" customModuleProvider="target">
@@ -1068,7 +1203,6 @@
                                                     <outlet property="placeImageView" destination="SeQ-Sz-ie9" id="zpR-MJ-exo"/>
                                                     <outlet property="placeNameLabel" destination="pdU-NB-Gcf" id="27m-m2-y6e"/>
                                                     <outlet property="starButton" destination="bqT-q2-Dk9" id="nCm-PH-KCy"/>
-                                                    <segue destination="b3Z-rC-oH0" kind="show" id="Xot-hR-CQr"/>
                                                 </connections>
                                             </tableViewCell>
                                         </prototypes>
@@ -1138,11 +1272,11 @@
                                         <rect key="frame" x="0.0" y="50" width="393" height="802"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <prototypes>
-                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MyPlaceTableViewCell" rowHeight="124" id="nVG-04-PVx" customClass="MyPlaceTableViewCell" customModule="Foodle" customModuleProvider="target">
+                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MyPlaceTableViewCell" rowHeight="124" id="nVG-04-PVx" customClass="MyPlaceTableViewCell" customModule="Foodle" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="50" width="393" height="124"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nVG-04-PVx" id="t9I-lH-vKJ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="393" height="124"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="362.66666666666669" height="124"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-T0-Mw2">
@@ -1171,7 +1305,6 @@
                                                 <connections>
                                                     <outlet property="circleImageView" destination="bbp-T0-Mw2" id="awE-Jp-PwH"/>
                                                     <outlet property="listNameLabel" destination="upu-8b-6YD" id="6rz-se-Biy"/>
-                                                    <segue destination="9sO-5h-AcD" kind="show" id="A5L-8F-OVr"/>
                                                 </connections>
                                             </tableViewCell>
                                         </prototypes>

--- a/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
+++ b/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
@@ -11,7 +11,8 @@ class MyPlaceScrollableViewController: UIViewController {
 
     @IBOutlet weak var headerView: UIView!
     @IBOutlet weak var tableView: UITableView!
-    
+    @IBOutlet weak var stackView: UIStackView!
+       
     var fullView: CGFloat = 100
     var partialView: CGFloat {
         UIScreen.main.bounds.height - headerView.bounds.height - (self.tabBarController?.tabBar.bounds.height ?? 49)
@@ -19,8 +20,6 @@ class MyPlaceScrollableViewController: UIViewController {
     var secondPartialView: CGFloat {
         UIScreen.main.bounds.height - headerView.bounds.height - 300 - (self.tabBarController?.tabBar.bounds.height ?? 49)
     }
-
-        
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -31,6 +30,8 @@ class MyPlaceScrollableViewController: UIViewController {
         gesture.delegate = self
         view.addGestureRecognizer(gesture)
     }
+    
+    var childView: UIView!
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -46,6 +47,11 @@ class MyPlaceScrollableViewController: UIViewController {
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
+    }
+    
+    @objc func returnToList(_ sender: UIButton){
+        stackView.removeArrangedSubview(childView)
+        sender.removeFromSuperview()
     }
     
     @objc func panGesture(_ recognizer: UIPanGestureRecognizer) {
@@ -101,7 +107,20 @@ extension MyPlaceScrollableViewController: UITableViewDelegate, UITableViewDataS
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let bottomSheetVCSB = UIStoryboard(name: "Jinhee", bundle: nil)
+        let bottomSheetVC = bottomSheetVCSB.instantiateViewController(withIdentifier: "MyPlaceTableViewController")
+        self.addChild(bottomSheetVC)
         
+        childView = bottomSheetVC.view
+        stackView.addArrangedSubview(childView)
+        bottomSheetVC.didMove(toParent: self)
+        
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        button.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
+        button.setTitleColor(.accent, for: .normal)
+        
+        self.view.addSubview(button)
+        button.addTarget(self, action: #selector(returnToList), for: .touchUpInside)
     }
         
 }

--- a/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
+++ b/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
@@ -66,7 +66,7 @@ class MyPlaceScrollableViewController: UIViewController {
             
             UIView.animate(withDuration: duration, delay: 0.0, options: [.allowUserInteraction], animations: {
                 if  velocity.y >= 0 {
-                    self.view.frame = CGRect(x: 0, y: self.partialView, width: self.view.frame.width, height: self.view.frame.height)
+                    self.view.frame = CGRect(x: 0, y: self.secondPartialView, width: self.view.frame.width, height: self.view.frame.height)
                 } else {
                     self.view.frame = CGRect(x: 0, y: self.fullView, width: self.view.frame.width, height: self.view.frame.height)
                 }
@@ -98,6 +98,10 @@ extension MyPlaceScrollableViewController: UITableViewDelegate, UITableViewDataS
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "MyPlaceTableViewCell") as! MyPlaceTableViewCell
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
     }
         
 }

--- a/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
+++ b/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
@@ -32,6 +32,7 @@ class MyPlaceScrollableViewController: UIViewController {
     }
     
     var childView: UIView!
+    var button: UIButton?
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -52,6 +53,7 @@ class MyPlaceScrollableViewController: UIViewController {
     @objc func returnToList(_ sender: UIButton){
         stackView.removeArrangedSubview(childView)
         sender.removeFromSuperview()
+        button = nil
     }
     
     @objc func panGesture(_ recognizer: UIPanGestureRecognizer) {
@@ -115,12 +117,18 @@ extension MyPlaceScrollableViewController: UITableViewDelegate, UITableViewDataS
         stackView.addArrangedSubview(childView)
         bottomSheetVC.didMove(toParent: self)
         
-        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        button.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
-        button.setTitleColor(.accent, for: .normal)
+        stackView.setNeedsLayout()
+        stackView.layoutIfNeeded()
         
-        self.view.addSubview(button)
-        button.addTarget(self, action: #selector(returnToList), for: .touchUpInside)
+        if button == nil{
+            button = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+            button?.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
+            button?.setTitleColor(.accent, for: .normal)
+            
+            self.view.addSubview(button ?? UIButton())
+            button?.addTarget(self, action: #selector(returnToList), for: .touchUpInside)
+
+        }
     }
         
 }
@@ -133,7 +141,7 @@ extension MyPlaceScrollableViewController: UIGestureRecognizerDelegate {
         let direction = gesture.velocity(in: view).y
 
         let y = view.frame.minY
-        if (y == fullView && tableView.contentOffset.y == 0 && direction > 0) || (y == partialView) {
+        if (y == fullView && tableView.contentOffset.y == 0 && direction > 0) || (y == secondPartialView) {
             tableView.isScrollEnabled = false
         } else {
             tableView.isScrollEnabled = true

--- a/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
+++ b/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
@@ -13,7 +13,13 @@ class MyPlaceScrollableViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     
     var fullView: CGFloat = 100
-    var partialView: CGFloat = UIScreen.main.bounds.height - 130
+    var partialView: CGFloat {
+        UIScreen.main.bounds.height - headerView.bounds.height - (self.tabBarController?.tabBar.bounds.height ?? 49)
+    }
+    var secondPartialView: CGFloat {
+        UIScreen.main.bounds.height - headerView.bounds.height - 300 - (self.tabBarController?.tabBar.bounds.height ?? 49)
+    }
+
         
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -31,7 +37,7 @@ class MyPlaceScrollableViewController: UIViewController {
         
         UIView.animate(withDuration: 0.6, animations: { [weak self] in
             let frame = self?.view.frame
-            let yComponent = self?.partialView
+            let yComponent = self?.secondPartialView
             self?.view.frame = CGRect(x: 0, y: yComponent!, width: frame!.width, height: frame!.height - 100)
             })
         self.view.roundCorners(corners: [.topLeft,.topRight], radius: 10)

--- a/Foodle/Foodle/ViewController/MyPlaceTableViewController.swift
+++ b/Foodle/Foodle/ViewController/MyPlaceTableViewController.swift
@@ -1,0 +1,32 @@
+//
+//  MyPlaceTableViewController.swift
+//  Foodle
+//
+//  Created by 루딘 on 5/23/24.
+//
+
+import UIKit
+
+class MyPlaceTableViewController: UITableViewController {
+        
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 30
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 170
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "resultTableViewCell") as! ResultTableViewcell
+        return cell
+    }
+}

--- a/Foodle/Foodle/ViewController/ScrollableBottomSheetViewController.swift
+++ b/Foodle/Foodle/ViewController/ScrollableBottomSheetViewController.swift
@@ -6,11 +6,17 @@ class ScrollableBottomSheetViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     
     var fullView: CGFloat = 100
-    var partialView: CGFloat = UIScreen.main.bounds.height - 130
+    var partialView: CGFloat {
+        UIScreen.main.bounds.height - 130
+    }
+    var secondPartialView: CGFloat {
+        UIScreen.main.bounds.height - headerView.bounds.height - 245  - (self.tabBarController?.tabBar.bounds.height ?? 49)
+    }
+
+
         
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         tableView.delegate = self
         tableView.dataSource = self
         
@@ -24,7 +30,10 @@ class ScrollableBottomSheetViewController: UIViewController {
         
         UIView.animate(withDuration: 0.6, animations: { [weak self] in
             let frame = self?.view.frame
-            let yComponent = self?.partialView
+            let yComponent = self?.secondPartialView
+            
+            print(self?.partialView)
+            print(self?.secondPartialView)
             self?.view.frame = CGRect(x: 0, y: yComponent!, width: frame!.width, height: frame!.height - 100)
             })
         self.view.roundCorners(corners: [.topLeft,.topRight], radius: 10)

--- a/Foodle/Foodle/ViewController/ScrollableBottomSheetViewController.swift
+++ b/Foodle/Foodle/ViewController/ScrollableBottomSheetViewController.swift
@@ -32,8 +32,6 @@ class ScrollableBottomSheetViewController: UIViewController {
             let frame = self?.view.frame
             let yComponent = self?.secondPartialView
             
-            print(self?.partialView)
-            print(self?.secondPartialView)
             self?.view.frame = CGRect(x: 0, y: yComponent!, width: frame!.width, height: frame!.height - 100)
             })
         self.view.roundCorners(corners: [.topLeft,.topRight], radius: 10)
@@ -62,7 +60,7 @@ class ScrollableBottomSheetViewController: UIViewController {
             
             UIView.animate(withDuration: duration, delay: 0.0, options: [.allowUserInteraction], animations: {
                 if  velocity.y >= 0 {
-                    self.view.frame = CGRect(x: 0, y: self.partialView, width: self.view.frame.width, height: self.view.frame.height)
+                    self.view.frame = CGRect(x: 0, y: self.secondPartialView, width: self.view.frame.width, height: self.view.frame.height)
                 } else {
                     self.view.frame = CGRect(x: 0, y: self.fullView, width: self.view.frame.width, height: self.view.frame.height)
                 }
@@ -94,6 +92,15 @@ extension ScrollableBottomSheetViewController: UITableViewDelegate, UITableViewD
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "resultTableViewCell") as! ResultTableViewcell
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        UIView.animate(withDuration: 0.6, animations: { [weak self] in
+            let frame = self?.view.frame
+            let yComponent = self?.secondPartialView
+            
+            self?.view.frame = CGRect(x: 0, y: yComponent!, width: frame!.width, height: frame!.height)
+        })
     }
     
 }


### PR DESCRIPTION
## 추가된 사항
- 탭바가 투명한 문제를 해결했습니다
- 마이플레이스뷰의 리스트를 선택 시 segue이동이 아닌 stackView에 add하는 방식을 채택했습니다.
- 바텀시트뷰의 초기 높이를 수정했습니다.

## 고쳐야 할 사항
- 마이플레이스뷰의 리스트를 처음엔 두 번 선택해야 stackView에 add된 플레이스 목록이 제대로 출력됩니다.
  - 디버깅해보니 didselect 자체는 한 번에 실행되는 것을 보면 플레이스목록의 테이블 뷰가 초기에 제대로 생성되지 않는 듯 합니다.

close #24 