### PR TITLE
[feat] 일정 목록 뷰 데이터 표시 처리

### DIFF
--- a/Foodle/Foodle.xcodeproj/project.pbxproj
+++ b/Foodle/Foodle.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		4BF8193E2C292BD6006BE538 /* Friend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF8193D2C292BD6006BE538 /* Friend.swift */; };
 		4BF819402C292BE5006BE538 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF8193F2C292BE5006BE538 /* User.swift */; };
 		4BF819422C292ED0006BE538 /* PlaceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF819412C292ED0006BE538 /* PlaceList.swift */; };
+		4BFA46132C2BB8DA00240F4E /* RoundedCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFA46122C2BB8DA00240F4E /* RoundedCollectionViewCell.swift */; };
 		923B80FE2C0230C600B771E7 /* ScheduleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923B80FD2C0230C600B771E7 /* ScheduleListViewController.swift */; };
 		927E19CE2C0239AD004D9F96 /* Minjeong.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 927E19CD2C0239AD004D9F96 /* Minjeong.storyboard */; };
 		92B688482BB0A20400D7DF2C /* LoginViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B688472BB0A20400D7DF2C /* LoginViewCell.swift */; };
@@ -93,6 +94,7 @@
 		4BF8193D2C292BD6006BE538 /* Friend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Friend.swift; sourceTree = "<group>"; };
 		4BF8193F2C292BE5006BE538 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		4BF819412C292ED0006BE538 /* PlaceList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceList.swift; sourceTree = "<group>"; };
+		4BFA46122C2BB8DA00240F4E /* RoundedCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCollectionViewCell.swift; sourceTree = "<group>"; };
 		923B80FD2C0230C600B771E7 /* ScheduleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleListViewController.swift; sourceTree = "<group>"; };
 		927E19CC2C0239AD004D9F96 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Minjeong.storyboard; sourceTree = "<group>"; };
 		927E19CF2C0239AD004D9F96 /* mul */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = mul; path = mul.lproj/Minjeong.xcstrings; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 				92EA73162BF0D1830075472C /* MyPageViewCell.swift */,
 				4B70D9C22BF5BAF600F3C965 /* MyPlaceTableViewCell.swift */,
 				4BB965CA2C23C44D00F7E429 /* ColorCollectionViewCell.swift */,
+				4BFA46122C2BB8DA00240F4E /* RoundedCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -325,6 +328,7 @@
 				4B73950C2BAC3187006843DB /* SelectFriendsViewController.swift in Sources */,
 				4B1122402BE351D200A2E577 /* ResultTableViewcell.swift in Sources */,
 				4BA12D7F2BA004CE00BC4EB0 /* AppDelegate.swift in Sources */,
+				4BFA46132C2BB8DA00240F4E /* RoundedCollectionViewCell.swift in Sources */,
 				4BF8193A2C292B8E006BE538 /* MeetingPlace.swift in Sources */,
 				4B8D3EF22C22B2BC00A344D1 /* AddPlaceViewController.swift in Sources */,
 				4BF8193E2C292BD6006BE538 /* Friend.swift in Sources */,

--- a/Foodle/Foodle/Base.lproj/Jinhee.storyboard
+++ b/Foodle/Foodle/Base.lproj/Jinhee.storyboard
@@ -214,6 +214,59 @@
                                                                 <segue destination="fJx-ZF-KQ8" kind="show" id="5FZ-ju-y38"/>
                                                             </connections>
                                                         </collectionViewCell>
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" contentMode="center" reuseIdentifier="EmptyMeetingCell" id="Nwn-vF-3HQ" customClass="RoundedCollectionViewCell" customModule="Foodle" customModuleProvider="target">
+                                                            <rect key="frame" x="550" y="0.0" width="350" height="150"/>
+                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="akS-su-Gk8">
+                                                                <rect key="frame" x="0.0" y="0.0" width="350" height="150"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <subviews>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9dW-G7-KPC">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="350" height="150"/>
+                                                                        <subviews>
+                                                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="dEc-YN-FW5">
+                                                                                <rect key="frame" x="100.66666666666669" y="43.666666666666657" width="149" height="63"/>
+                                                                                <subviews>
+                                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="xmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Y6P-sc-0ZB">
+                                                                                        <rect key="frame" x="0.0" y="19" width="30" height="25"/>
+                                                                                        <color key="tintColor" systemColor="systemRedColor"/>
+                                                                                        <constraints>
+                                                                                            <constraint firstAttribute="width" constant="30" id="sHw-a5-Plb"/>
+                                                                                            <constraint firstAttribute="height" constant="30" id="zBB-HV-afq"/>
+                                                                                        </constraints>
+                                                                                    </imageView>
+                                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="일정이 없어요" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="45r-7T-NuJ">
+                                                                                        <rect key="frame" x="29.999999999999986" y="0.0" width="119.00000000000001" height="63"/>
+                                                                                        <constraints>
+                                                                                            <constraint firstAttribute="height" constant="63" id="LZx-a3-u88"/>
+                                                                                        </constraints>
+                                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                                                                        <nil key="textColor"/>
+                                                                                        <nil key="highlightedColor"/>
+                                                                                        <lineBreakStrategy key="lineBreakStrategy" hangulWordPriority="YES"/>
+                                                                                    </label>
+                                                                                </subviews>
+                                                                            </stackView>
+                                                                        </subviews>
+                                                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <constraints>
+                                                                            <constraint firstItem="dEc-YN-FW5" firstAttribute="centerY" secondItem="9dW-G7-KPC" secondAttribute="centerY" id="a2X-p8-vtV"/>
+                                                                            <constraint firstAttribute="width" constant="350" id="byl-UW-RMp"/>
+                                                                            <constraint firstItem="dEc-YN-FW5" firstAttribute="centerX" secondItem="9dW-G7-KPC" secondAttribute="centerX" id="gk5-3I-pbR"/>
+                                                                            <constraint firstAttribute="height" constant="150" id="iiC-bf-6i3"/>
+                                                                        </constraints>
+                                                                    </view>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="bottom" secondItem="9dW-G7-KPC" secondAttribute="bottom" id="Fwt-Pt-Enq"/>
+                                                                    <constraint firstItem="9dW-G7-KPC" firstAttribute="leading" secondItem="akS-su-Gk8" secondAttribute="leading" id="NwU-Js-eZq"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="9dW-G7-KPC" secondAttribute="trailing" id="i5j-uZ-RKY"/>
+                                                                    <constraint firstItem="9dW-G7-KPC" firstAttribute="top" secondItem="akS-su-Gk8" secondAttribute="top" id="jtI-yB-g5o"/>
+                                                                </constraints>
+                                                            </collectionViewCellContentView>
+                                                            <size key="customSize" width="350" height="150"/>
+                                                        </collectionViewCell>
                                                     </cells>
                                                 </collectionView>
                                             </subviews>
@@ -1687,16 +1740,22 @@
             <color red="0.43529411764705883" green="0.44313725490196076" blue="0.47450980392156861" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondarySystemFillColor">
-            <color red="0.47058823529411764" green="0.47058823529411764" blue="0.50196078431372548" alpha="0.16" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.47058823529999999" green="0.47058823529999999" blue="0.50196078430000002" alpha="0.16" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Foodle/Foodle/Base.lproj/Minjeong.storyboard
+++ b/Foodle/Foodle/Base.lproj/Minjeong.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Map view configurations" minToolsVersion="14.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -379,6 +379,9 @@
                             <datePicker contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" style="inline" translatesAutoresizingMaskIntoConstraints="NO" id="0yD-7z-eqI">
                                 <rect key="frame" x="36" y="112" width="304" height="295"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <connections>
+                                    <action selector="selectedDate:" destination="CXr-rK-u3c" eventType="valueChanged" id="ZBO-yF-JFS"/>
+                                </connections>
                             </datePicker>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="hJS-oa-CyT">
                                 <rect key="frame" x="16" y="449" width="361" height="320"/>
@@ -399,7 +402,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="2024/01/01 월" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kX2-FI-odJ">
-                                                    <rect key="frame" x="24.999999999999943" y="18" width="116.00000000000006" height="22"/>
+                                                    <rect key="frame" x="25" y="18" width="200" height="22"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                                     <nil key="textColor"/>
@@ -452,7 +455,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gAc-q1-gq2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-703" y="689"/>
+            <point key="canvasLocation" x="-703.05343511450383" y="688.73239436619724"/>
         </scene>
         <!--My Page View Cell-->
         <scene sceneID="KXn-hs-8aN">

--- a/Foodle/Foodle/Cell/MainCollectionViewCell.swift
+++ b/Foodle/Foodle/Cell/MainCollectionViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MainCollectionViewCell: UICollectionViewCell {
+class MainCollectionViewCell: RoundedCollectionViewCell {
     @IBOutlet weak var date: UILabel!
     @IBOutlet weak var meetingName: UILabel!
     @IBOutlet weak var placeName: UILabel!
@@ -19,7 +19,6 @@ class MainCollectionViewCell: UICollectionViewCell {
     }
     
     func prepare(bgColor: UIColor, textColor: UIColor){
-        self.layer.cornerRadius = 10
         self.cardView.backgroundColor = bgColor
         
         self.date.textColor = textColor

--- a/Foodle/Foodle/Cell/MainTableViewCell.swift
+++ b/Foodle/Foodle/Cell/MainTableViewCell.swift
@@ -41,9 +41,9 @@ extension MainTableViewCell: UICollectionViewDelegate, UICollectionViewDataSourc
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         switch self.section {
         case 0:
-            return dummyMeetings[index!].places.count
+            return dummyMeetings.isEmpty ? 1 : dummyMeetings[index!].places.count
         case 1:
-            return dummyMeetingsUpcoming[index!].places.count
+            return dummyMeetingsUpcoming.isEmpty ? 1 : dummyMeetingsUpcoming[index!].places.count
         default:
             return 0
         }
@@ -52,26 +52,34 @@ extension MainTableViewCell: UICollectionViewDelegate, UICollectionViewDataSourc
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch self.section{
         case 0:
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "mainCollectionViewCell", for: indexPath) as! MainCollectionViewCell
-            let target = dummyMeetings[index!]
-            cell.date.text = target.dateString
-            cell.meetingName.text = target.name
-            cell.order.text = "\(indexPath.item + 1)"
-            cell.placeName.text = target.places[indexPath.item]?.place?.placeName
-            cell.placeTime.text = target.places[indexPath.item]?.timeString
-            cell.prepare(bgColor: self.bgColor ?? .secondAccent, textColor: textColor ?? .black)
-            
-            return cell
-            
+            if dummyMeetings.isEmpty{
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "EmptyMeetingCell", for: indexPath) as! RoundedCollectionViewCell
+                return cell
+            }else{
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "mainCollectionViewCell", for: indexPath) as! MainCollectionViewCell
+                let target = dummyMeetings[index!]
+                cell.date.text = target.dateString
+                cell.meetingName.text = target.name
+                cell.order.text = "\(indexPath.item + 1)"
+                cell.placeName.text = target.places[indexPath.item]?.place?.placeName
+                cell.placeTime.text = target.places[indexPath.item]?.timeString
+                cell.prepare(bgColor: self.bgColor ?? .secondAccent, textColor: textColor ?? .black)
+                
+                return cell
+            }
         case 1:
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "upcomingCell", for: indexPath) as! UpcomingCollectionViewCell
-            let target = dummyMeetingsUpcoming[indexPath.row]
-            cell.dDay.text = target.dDay
-            cell.date.text = target.dateString
-            cell.meetName.text = target.name
-            cell.prepare()
-            
-            return cell
+            if dummyMeetingsUpcoming.isEmpty{
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "EmptyMeetingCell", for: indexPath) as! RoundedCollectionViewCell
+                return cell
+            } else {
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "upcomingCell", for: indexPath) as! UpcomingCollectionViewCell
+                let target = dummyMeetingsUpcoming[indexPath.row]
+                cell.dDay.text = target.dDay
+                cell.date.text = target.dateString
+                cell.meetName.text = target.name
+                
+                return cell
+            }
         default: return UICollectionViewCell()
         }
     }

--- a/Foodle/Foodle/Cell/MainTableViewCell.swift
+++ b/Foodle/Foodle/Cell/MainTableViewCell.swift
@@ -41,9 +41,9 @@ extension MainTableViewCell: UICollectionViewDelegate, UICollectionViewDataSourc
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         switch self.section {
         case 0:
-            return dummyMeetings.isEmpty ? 1 : dummyMeetings[index!].places.count
+            return dummyTodayMeetings.isEmpty ? 1 : dummyTodayMeetings[index!].places.count
         case 1:
-            return dummyMeetingsUpcoming.isEmpty ? 1 : dummyMeetingsUpcoming[index!].places.count
+            return dummyMeetingsUpcoming.isEmpty ? 1 : dummyMeetingsUpcoming.count
         default:
             return 0
         }
@@ -52,18 +52,18 @@ extension MainTableViewCell: UICollectionViewDelegate, UICollectionViewDataSourc
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch self.section{
         case 0:
-            if dummyMeetings.isEmpty{
+            if dummyTodayMeetings.isEmpty{
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "EmptyMeetingCell", for: indexPath) as! RoundedCollectionViewCell
                 return cell
             }else{
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "mainCollectionViewCell", for: indexPath) as! MainCollectionViewCell
-                let target = dummyMeetings[index!]
-                cell.date.text = target.dateString
-                cell.meetingName.text = target.name
-                cell.order.text = "\(indexPath.item + 1)"
-                cell.placeName.text = target.places[indexPath.item]?.place?.placeName
-                cell.placeTime.text = target.places[indexPath.item]?.timeString
-                cell.prepare(bgColor: self.bgColor ?? .secondAccent, textColor: textColor ?? .black)
+                let target = dummyTodayMeetings[index!]
+                    cell.date.text = target.dateString
+                    cell.meetingName.text = target.name
+                    cell.order.text = "\(indexPath.item + 1)"
+                    cell.placeName.text = target.places[indexPath.item]?.place?.placeName
+                    cell.placeTime.text = target.places[indexPath.item]?.timeString
+                    cell.prepare(bgColor: self.bgColor ?? .secondAccent, textColor: textColor ?? .black)
                 
                 return cell
             }
@@ -74,10 +74,9 @@ extension MainTableViewCell: UICollectionViewDelegate, UICollectionViewDataSourc
             } else {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "upcomingCell", for: indexPath) as! UpcomingCollectionViewCell
                 let target = dummyMeetingsUpcoming[indexPath.row]
-                cell.dDay.text = target.dDay
-                cell.date.text = target.dateString
-                cell.meetName.text = target.name
-                
+                    cell.dDay.text = target.dDay
+                    cell.date.text = target.dateString
+                    cell.meetName.text = target.name
                 return cell
             }
         default: return UICollectionViewCell()

--- a/Foodle/Foodle/Cell/RoundedCollectionViewCell.swift
+++ b/Foodle/Foodle/Cell/RoundedCollectionViewCell.swift
@@ -1,0 +1,15 @@
+//
+//  RoundedCollectionViewCell.swift
+//  Foodle
+//
+//  Created by 루딘 on 6/26/24.
+//
+
+import UIKit
+
+class RoundedCollectionViewCell: UICollectionViewCell {
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.layer.cornerRadius = 10
+    }
+}

--- a/Foodle/Foodle/Cell/UpcomingCollectionViewCell.swift
+++ b/Foodle/Foodle/Cell/UpcomingCollectionViewCell.swift
@@ -7,13 +7,10 @@
 
 import UIKit
 
-class UpcomingCollectionViewCell: UICollectionViewCell {
+class UpcomingCollectionViewCell: RoundedCollectionViewCell {
     @IBOutlet weak var date: UILabel!
     @IBOutlet weak var dDay: UILabel!
     @IBOutlet weak var meetName: UILabel!
     @IBOutlet weak var cardView: UIView!
     
-    func prepare(){
-        cardView.layer.cornerRadius = 10
-    }
 }

--- a/Foodle/Foodle/Model/Meeting.swift
+++ b/Foodle/Foodle/Model/Meeting.swift
@@ -37,9 +37,9 @@ class Meeting{
     }
 }
 
-func getToday(meetings: [Meeting]) -> [Meeting] {
+func getToday(meetings: [Meeting], date: Date = Date()) -> [Meeting] {
     meetings.filter {
-        let today = Date()
+        let today = date
         if let meetingday = $0.date{
             let calendar = Calendar.current
             return calendar.isDate(today, inSameDayAs: meetingday)

--- a/Foodle/Foodle/Model/Meeting.swift
+++ b/Foodle/Foodle/Model/Meeting.swift
@@ -37,9 +37,32 @@ class Meeting{
     }
 }
 
+func getToday(meetings: [Meeting]) -> [Meeting] {
+    meetings.filter {
+        let today = Date()
+        if let meetingday = $0.date{
+            let calendar = Calendar.current
+            return calendar.isDate(today, inSameDayAs: meetingday)
+        }
+        else {return false}
+    }
+}
+
+func getUpcoming(meetings: [Meeting]) -> [Meeting] {
+    meetings.filter {
+        let today = Date()
+        if let meetingday = $0.date{
+            let calendar = Calendar.current
+            return !calendar.isDate(today, inSameDayAs: meetingday) && today < meetingday
+        }
+        else {return false}
+    }
+}
+
 let dummyMeetings = [Meeting(joiners: [dummyUser, dummyUser2], name: "확인용 미팅", date: Date(), places: dummyMeetingPlaces),
-                    Meeting(joiners: [dummyUser, dummyUser2], name: "확인용 미팅2", date: Date(), places: dummyMeetingPlaces),
-                    Meeting(joiners: [dummyUser, dummyUser2], name: "확인용 미팅3", date: Date(), places: dummyMeetingPlaces)]
-let dummyMeetingsUpcoming = [Meeting(joiners: [dummyUser, dummyUser2], name: "내일 미팅", date: Calendar.current.date(byAdding: .day, value: 1, to: Date())!, places: dummyMeetingPlaces),
-                             Meeting(joiners: [dummyUser, dummyUser2], name: "내일 미팅2", date: Calendar.current.date(byAdding: .day, value: 1, to: Date())!, places: dummyMeetingPlaces),
-                             Meeting(joiners: [dummyUser, dummyUser2], name: "내일 미팅3", date: Calendar.current.date(byAdding: .day, value: 1, to: Date())!, places: dummyMeetingPlaces)]
+                     Meeting(joiners: [dummyUser, dummyUser2], name: "확인용 미팅2", date: Date(), places: dummyMeetingPlaces),
+                     Meeting(joiners: [dummyUser, dummyUser2], name: "확인용 미팅3", date: Date(), places: dummyMeetingPlaces), Meeting(joiners: [dummyUser, dummyUser2], name: "내일 미팅", date: Calendar.current.date(byAdding: .day, value: 1, to: Date())!, places: dummyMeetingPlaces),
+                     Meeting(joiners: [dummyUser, dummyUser2], name: "내일 미팅2", date: Calendar.current.date(byAdding: .day, value: 1, to: Date())!, places: dummyMeetingPlaces),
+                     Meeting(joiners: [dummyUser, dummyUser2], name: "내일 미팅3", date: Calendar.current.date(byAdding: .day, value: 1, to: Date())!, places: dummyMeetingPlaces)]
+let dummyTodayMeetings = getToday(meetings: dummyMeetings)
+let dummyMeetingsUpcoming = getUpcoming(meetings: dummyMeetings)

--- a/Foodle/Foodle/ViewController/MainViewController.swift
+++ b/Foodle/Foodle/ViewController/MainViewController.swift
@@ -152,7 +152,7 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section{
-        case 0: return dummyMeetings.count
+        case 0: return dummyMeetings.isEmpty ? 1 : dummyMeetings.count
         case 1: return 1
         default: return 0
         }

--- a/Foodle/Foodle/ViewController/MainViewController.swift
+++ b/Foodle/Foodle/ViewController/MainViewController.swift
@@ -47,6 +47,8 @@ class MainViewController: UIViewController {
 
         addSearchBar()
         addProfileIcon(nil)
+        
+        print(dummyMeetingsUpcoming)
     }
     
     func addSearchBar(){
@@ -152,7 +154,7 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section{
-        case 0: return dummyMeetings.isEmpty ? 1 : dummyMeetings.count
+        case 0: return dummyTodayMeetings.isEmpty ? 1 : dummyTodayMeetings.count
         case 1: return 1
         default: return 0
         }

--- a/Foodle/Foodle/ViewController/ScheduleListViewController.swift
+++ b/Foodle/Foodle/ViewController/ScheduleListViewController.swift
@@ -7,21 +7,32 @@
 
 import UIKit
 
-class ScheduleListViewController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate{
-    let scheList: [Schedule] = Schedule.list
+class ScheduleListViewController: UIViewController{
     
     @IBOutlet weak var scheListLabel: UILabel!
     @IBOutlet weak var calendar: UIDatePicker!
     @IBOutlet weak var collectionView: UICollectionView!
     
+    var date = Date()
+    
+    @IBAction func selectedDate(_ sender: UIDatePicker) {
+        date = sender.date
+        collectionView.reloadData()
+    }
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         collectionView.dataSource = self
         collectionView.delegate = self
+        calendar.date = date
     }
     
+}
+
+extension ScheduleListViewController: UICollectionViewDataSource, UICollectionViewDelegate{
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return scheList.count
+        return getToday(meetings: dummyMeetings, date: date).count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -29,29 +40,13 @@ class ScheduleListViewController: UIViewController, UICollectionViewDataSource, 
             fatalError("Unable to dequeue ScheduleCollectionViewCell")
             }
         
-        let schedule = scheList[indexPath.item]
-        cell.scheNameLabel.text = schedule.scheName
+        let schedule = getToday(meetings: dummyMeetings, date: date)[indexPath.item]
+        cell.scheNameLabel.text = schedule.name
         
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy/MM/dd"
-        cell.scheDateLabel.text = dateFormatter.string(from: schedule.scheDate)
+        cell.scheDateLabel.text = schedule.dateString
                 
         return cell
     }
-}
-
-struct Schedule {
-    let scheDate: Date
-    let scheName: String
-}
-
-extension Schedule {
-    static let list: [Schedule] = [
-        Schedule(scheDate: Calendar.current.date(from: DateComponents(year: 2024, month: 5, day: 26))!, scheName: "고등학교 동창회"),
-        Schedule(scheDate: Calendar.current.date(from: DateComponents(year: 2024, month: 5, day: 27))!, scheName: "친구 결혼식"),
-        Schedule(scheDate: Calendar.current.date(from: DateComponents(year: 2024, month: 5, day: 28))!, scheName: "회사 미팅"),
-        Schedule(scheDate: Calendar.current.date(from: DateComponents(year: 2024, month: 5, day: 28))!, scheName: "맛집 탐방")
-    ]
 }
 
 class ScheduleCollectionViewCell: UICollectionViewCell {


### PR DESCRIPTION
## 추가된 사항
- 일정 목록 뷰 데이터 표시를 더미데이터에 연동되도록 변경
- Meeting 모델의 날짜별 분류를 위한 메소드 추가
- 메인 화면에서 일정이 없을 시 처리 추가
Close #34 

<img width="546" alt="image" src="https://github.com/SoySauceFriedChicken/front/assets/65944851/702de817-6381-4f83-9a88-e2209d4a689d">
