### PR TITLE
[feat] 장소 검색 기능 구현 및 마이플레이스 일정부분 서버 데이터 연결

### DIFF
--- a/Foodle/Foodle.xcodeproj/project.pbxproj
+++ b/Foodle/Foodle.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4B1122392BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1122382BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift */; };
 		4B1122402BE351D200A2E577 /* ResultTableViewcell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B11223F2BE351D200A2E577 /* ResultTableViewcell.swift */; };
 		4B1261372BA31450002F52BD /* UpcomingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1261362BA31450002F52BD /* UpcomingCollectionViewCell.swift */; };
+		4B1C91B02C4611BC00CCB03E /* URLExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1C91AF2C4611BC00CCB03E /* URLExtension.swift */; };
 		4B23DBDF2BFEF09600E5E4FD /* MyPlaceTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B23DBDE2BFEF09600E5E4FD /* MyPlaceTableViewController.swift */; };
 		4B5D9B6D2BBE3FFB00F1BD58 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D9B6C2BBE3FFB00F1BD58 /* SearchViewController.swift */; };
 		4B5D9B6F2BBE406400F1BD58 /* DetailPlaceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D9B6E2BBE406400F1BD58 /* DetailPlaceViewController.swift */; };
@@ -64,6 +65,7 @@
 		4B1122382BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableBottomSheetViewController.swift; sourceTree = "<group>"; };
 		4B11223F2BE351D200A2E577 /* ResultTableViewcell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTableViewcell.swift; sourceTree = "<group>"; };
 		4B1261362BA31450002F52BD /* UpcomingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingCollectionViewCell.swift; sourceTree = "<group>"; };
+		4B1C91AF2C4611BC00CCB03E /* URLExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtension.swift; sourceTree = "<group>"; };
 		4B23DBDE2BFEF09600E5E4FD /* MyPlaceTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPlaceTableViewController.swift; sourceTree = "<group>"; };
 		4B5D9B6C2BBE3FFB00F1BD58 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		4B5D9B6E2BBE406400F1BD58 /* DetailPlaceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPlaceViewController.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				4B772F4B2C34F1DD00975B4C /* UIColorExtension.swift */,
 				4BE731822C3E2AA1008733C9 /* Server.swift */,
 				4BE731972C436A1C008733C9 /* LaunchingSegue.swift */,
+				4B1C91AF2C4611BC00CCB03E /* URLExtension.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -344,6 +347,7 @@
 				4B1122392BE33EA000A2E577 /* ScrollableBottomSheetViewController.swift in Sources */,
 				4B7395102BAC31BB006843DB /* AddMeetingPlaceViewController.swift in Sources */,
 				4B63886C2C2FB5E800ED10F0 /* Day.swift in Sources */,
+				4B1C91B02C4611BC00CCB03E /* URLExtension.swift in Sources */,
 				4B1261372BA31450002F52BD /* UpcomingCollectionViewCell.swift in Sources */,
 				4BF819402C292BE5006BE538 /* User.swift in Sources */,
 				4BF819422C292ED0006BE538 /* PlaceList.swift in Sources */,

--- a/Foodle/Foodle/Base.lproj/Jinhee.storyboard
+++ b/Foodle/Foodle/Base.lproj/Jinhee.storyboard
@@ -926,6 +926,8 @@
                         <outlet property="addressLabel" destination="WFs-gw-jpj" id="7sa-ox-Bu9"/>
                         <outlet property="distanceLabel" destination="S0f-xZ-0PP" id="jBT-Hm-lMl"/>
                         <outlet property="imageCollectionView" destination="Svm-xg-FRg" id="L61-AB-sXP"/>
+                        <outlet property="instaDescriptionLabel" destination="KEa-mm-4qc" id="lzA-b9-2QI"/>
+                        <outlet property="instaURLButton" destination="HMx-O9-IZC" id="Yjh-b5-FFY"/>
                         <outlet property="isWorkingLabel" destination="AiY-Cy-fYw" id="v0q-RD-ovL"/>
                         <outlet property="placeNameLabel" destination="BMj-iC-AfV" id="Mnh-Fi-CTh"/>
                         <outlet property="rateLabel" destination="2fQ-9d-Rb3" id="uE7-KA-acl"/>

--- a/Foodle/Foodle/Base.lproj/Jinhee.storyboard
+++ b/Foodle/Foodle/Base.lproj/Jinhee.storyboard
@@ -762,6 +762,7 @@
                                                             <subviews>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WZe-ZV-zSx">
                                                                     <rect key="frame" x="5" y="0.0" width="246" height="193"/>
+                                                                    <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="200" id="CbD-k7-zi2"/>
                                                                         <constraint firstAttribute="width" constant="256" id="DkX-tb-CMB"/>
@@ -966,8 +967,9 @@
                                                     <state key="normal" title="Button"/>
                                                     <buttonConfiguration key="configuration" style="plain" image="star" catalog="system"/>
                                                 </button>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dummy" translatesAutoresizingMaskIntoConstraints="NO" id="6Jp-r3-j60">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6Jp-r3-j60">
                                                     <rect key="frame" x="313" y="50" width="70" height="70"/>
+                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="70" id="7cC-Fd-s1v"/>
                                                         <constraint firstAttribute="height" constant="70" id="qRv-D3-7th"/>
@@ -1451,8 +1453,9 @@
                                                         <action selector="addPlaceToList:" destination="9sO-5h-AcD" eventType="touchUpInside" id="wg6-eI-BSY"/>
                                                     </connections>
                                                 </button>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dummy" translatesAutoresizingMaskIntoConstraints="NO" id="SeQ-Sz-ie9">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SeQ-Sz-ie9">
                                                     <rect key="frame" x="313" y="50" width="70" height="70"/>
+                                                    <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="70" id="caY-pA-t5b"/>
                                                         <constraint firstAttribute="height" constant="70" id="orw-gB-ZOg"/>
@@ -1848,7 +1851,6 @@
         <image name="Splash" width="256" height="256"/>
         <image name="checkmark" catalog="system" width="128" height="114"/>
         <image name="circle.fill" catalog="system" width="128" height="123"/>
-        <image name="dummy" width="210" height="150"/>
         <image name="house" catalog="system" width="128" height="104"/>
         <image name="map" catalog="system" width="128" height="112"/>
         <image name="pawprint" catalog="system" width="128" height="114"/>

--- a/Foodle/Foodle/Base.lproj/Jinhee.storyboard
+++ b/Foodle/Foodle/Base.lproj/Jinhee.storyboard
@@ -731,17 +731,17 @@
             <objects>
                 <viewController id="b3Z-rC-oH0" customClass="DetailPlaceViewController" customModule="Foodle" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kUP-ri-HED">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RlX-2u-jFg">
-                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="2gZ-95-yab">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="788.66666666666663"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="729.66666666666663"/>
                                         <subviews>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Svm-xg-FRg">
-                                                <rect key="frame" x="10" y="69" width="373" height="200"/>
+                                                <rect key="frame" x="10" y="10" width="373" height="200"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="200" id="G9O-sg-zit"/>
@@ -787,7 +787,7 @@
                                                 </connections>
                                             </collectionView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hfL-vD-A8D">
-                                                <rect key="frame" x="10" y="279" width="373" height="499.66666666666674"/>
+                                                <rect key="frame" x="10" y="220.00000000000003" width="373" height="499.66666666666674"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ZMk-jY-hcQ">
                                                         <rect key="frame" x="0.0" y="0.0" width="237.66666666666666" height="80.333333333333329"/>
@@ -870,7 +870,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="NdZ-md-o8o">
-                                                        <rect key="frame" x="0.0" y="283.33333333333337" width="204.33333333333334" height="216.33333333333337"/>
+                                                        <rect key="frame" x="0.0" y="283.33333333333331" width="204.33333333333334" height="216.33333333333331"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="영업 시간" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XuA-L8-bmJ">
                                                                 <rect key="frame" x="0.0" y="0.0" width="103.33333333333333" height="33.666666666666664"/>
@@ -879,7 +879,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zzF-Ac-8fb">
-                                                                <rect key="frame" x="0.0" y="43.666666666666629" width="204.33333333333334" height="40.666666666666657"/>
+                                                                <rect key="frame" x="0.0" y="43.666666666666686" width="204.33333333333334" height="40.666666666666657"/>
                                                                 <string key="text">월 9:00~13:00
 (브레이크 타임 12:00~12:30)</string>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -887,7 +887,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="화 9:00~13:00 수 9:00~13:00 목 9:00~13:00 금 9:00~13:00 토 9:00~13:00 일 9:00~13:00" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nop-50-FGT">
-                                                                <rect key="frame" x="0.0" y="94.333333333333258" width="108" height="122"/>
+                                                                <rect key="frame" x="0.0" y="94.333333333333314" width="108" height="122"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -1094,11 +1094,12 @@
                     </view>
                     <connections>
                         <outlet property="tableView" destination="Pqd-35-N8g" id="teZ-4d-CCr"/>
+                        <segue destination="b3Z-rC-oH0" kind="show" identifier="ToDetail" id="wwL-l4-wnF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eaV-eM-fOU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4429.7709923664124" y="-720.42253521126759"/>
+            <point key="canvasLocation" x="3653" y="855"/>
         </scene>
         <!--LoginView-->
         <scene sceneID="iay-o0-Hqv">
@@ -1734,7 +1735,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8JG-Sk-DqP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3469" y="-696"/>
+            <point key="canvasLocation" x="2708" y="855"/>
         </scene>
         <!--홈-->
         <scene sceneID="KjQ-nM-kRY">

--- a/Foodle/Foodle/Model/Meeting.swift
+++ b/Foodle/Foodle/Model/Meeting.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 var meetings: [Meeting]?
-let meetingsToday = getToday(meetings: meetings)
-let meetingsUpcoming = getUpcoming(meetings: meetings)
+var meetingsToday = getToday(meetings: meetings)
+var meetingsUpcoming = getUpcoming(meetings: meetings)
 
 struct Meeting:Codable{
     var mid: Int?

--- a/Foodle/Foodle/Model/Place.swift
+++ b/Foodle/Foodle/Model/Place.swift
@@ -25,16 +25,18 @@ struct Place: Codable{
 extension Place{
     var workingDay: Dictionary<Day, String> {
         var dict = [Day.월: "", Day.화: "", Day.수: "", Day.목: "", Day.금: "", Day.토: "", Day.일: ""]
-        for i in 0...6{
-            dict.updateValue(working?[i] ?? "", forKey: days[i])
+        guard let working else {return dict}
+        for i in 0 ..< working.count{
+            dict.updateValue(working[i], forKey: days[i])
         }
         
         return dict
     }
     var breakTimeDay: Dictionary<Day, String>{
         var dict = [Day.월: "", Day.화: "", Day.수: "", Day.목: "", Day.금: "", Day.토: "", Day.일: ""]
-        for i in 0...6{
-            dict.updateValue(breakTime?[i] ?? "", forKey: days[i])
+        guard let breakTime else {return dict}
+        for i in 0 ..< breakTime.count{
+            dict.updateValue(breakTime[i], forKey: days[i])
         }
         return dict
     }
@@ -45,6 +47,9 @@ extension Place{
     
     var close: String {
         var result = ""
+        if let working, working.isEmpty {
+            return "정보 없음"
+        }
         for time in workingDay{
             if time.value.isEmpty{
                 result.append("\(time.key.rawValue) ")
@@ -57,6 +62,9 @@ extension Place{
     }
     
     var isWorking: String{
+        if let working, working.isEmpty{
+            return "정보 없음"
+        }
         var result = "영업종료"
         let now = Date()
         let formatter = DateFormatter()
@@ -66,14 +74,17 @@ extension Place{
         formatter.dateFormat = "HH:mm"
         let nowTime = formatter.string(from: now)
         if let today {
+            
             let workingTime = workingDay[today]?.components(separatedBy: ["~", " "])
-            let bTime = breakTimeDay[today]?.components(separatedBy: ["~", " "])
-            if let workingTime{
+            
+            if let workingTime, !workingTime.isEmpty{
                 if workingTime[0] <= nowTime && workingTime[1] >= nowTime {
                     result = "영업중"
                 }
             }
-            if let bTime{
+            
+            let bTime = breakTimeDay[today]?.components(separatedBy: ["~", " "])
+            if let bTime, !bTime.isEmpty{
                 if bTime[0] <= nowTime && bTime[1] >= nowTime{
                     result = "브레이크타임"
                 }

--- a/Foodle/Foodle/Utility/Server.swift
+++ b/Foodle/Foodle/Utility/Server.swift
@@ -182,5 +182,49 @@ func fetchPlaceLists(_ uid: String, completion: @escaping ([PlaceList]?) -> Void
     task.resume()
 }
 
+func searchPlace(_ byName: String?, completion: @escaping ([Place]?) -> Void){
+    guard let byName else { return }
+    
+    var url = url!
+    url.append(path: "/api/place/byPlaceName")
+    url.append(queryItems: [URLQueryItem(name: "name", value: byName)])
+
+    let session = URLSession.shared
+    let task = session.dataTask(with: url) { data, response, error in
+        if error != nil{
+            completion(nil)
+            return
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse else
+        {
+            completion(nil)
+            return
+        }
+        
+        guard httpResponse.statusCode == 200 else
+        {
+            print(httpResponse.statusCode)
+            completion(nil)
+            return
+        }
+        
+        guard let data else
+        {
+            completion(nil)
+            return
+        }
+        
+        do{
+            let decoder = JSONDecoder()
+            let result = try decoder.decode([Place].self, from: data)
+            completion(result)
+        } catch {
+            print(error)
+            completion(nil)
+        }
+    }
+    task.resume()
+}
 
 

--- a/Foodle/Foodle/Utility/URLExtension.swift
+++ b/Foodle/Foodle/Utility/URLExtension.swift
@@ -1,0 +1,20 @@
+//
+//  URLExtension.swift
+//  Foodle
+//
+//  Created by 루딘 on 7/16/24.
+//
+
+import UIKit
+
+extension URL {
+    func asyncImage(completion: @escaping (UIImage?) -> Void) {
+        URLSession.shared.dataTask(with: self) { data, _, _ in
+            guard let data = data, let image = UIImage(data: data) else {
+                completion(nil)
+                return
+            }
+            completion(image)
+        }.resume()
+    }
+}

--- a/Foodle/Foodle/ViewController/DetailPlaceViewController.swift
+++ b/Foodle/Foodle/ViewController/DetailPlaceViewController.swift
@@ -30,6 +30,15 @@ class DetailPlaceViewController: UIViewController {
         distanceLabel.text = place?.distance
         rateLabel.text = "네이버 평점" + (place?.rate?.formatted() ?? "0")
         
+        showTime()
+    }
+    
+    func showTime(){
+        if let t = place?.working, t.isEmpty{
+            workingLabel.text = "정보 없음"
+            todayWorkingLabel.text = ""
+            return
+        }
         let formatter = DateFormatter()
         formatter.dateFormat = "E"
         formatter.locale =  Locale(identifier: "ko_KR")
@@ -50,8 +59,9 @@ class DetailPlaceViewController: UIViewController {
             str.append("\(work.key.rawValue) \(work.value)   브레이크타임 \(val)\n")
         }
         workingLabel.text = str
-        
+
     }
+    
     @IBAction func openReview(_ sender: Any) {
         if let str = place?.reviewURL, let url = URL(string: str) {
                 UIApplication.shared.open(url, options: [:])

--- a/Foodle/Foodle/ViewController/DetailPlaceViewController.swift
+++ b/Foodle/Foodle/ViewController/DetailPlaceViewController.swift
@@ -11,6 +11,8 @@ class DetailPlaceViewController: UIViewController {
     var place: Place?
     @IBOutlet weak var imageCollectionView: UICollectionView!
     
+    @IBOutlet weak var instaURLButton: UIButton!
+    @IBOutlet weak var instaDescriptionLabel: UILabel!
     @IBOutlet weak var placeNameLabel: UILabel!
     @IBOutlet weak var isWorkingLabel: UILabel!
     @IBOutlet weak var starButton: UIButton!
@@ -31,6 +33,16 @@ class DetailPlaceViewController: UIViewController {
         rateLabel.text = "네이버 평점" + (place?.rate?.formatted() ?? "0")
         
         showTime()
+        
+        guard let insta = place?.instaURL else {
+            instaURLButton.isHidden = true
+            instaDescriptionLabel.isHidden = true
+            return
+        }
+        if insta.isEmpty{
+            instaURLButton.isHidden = true
+            instaDescriptionLabel.isHidden = true
+        }
     }
     
     func showTime(){

--- a/Foodle/Foodle/ViewController/MainViewController.swift
+++ b/Foodle/Foodle/ViewController/MainViewController.swift
@@ -17,6 +17,7 @@ class MainViewController: UIViewController {
     
     lazy var buttons: [UIButton] = [self.addMeetButton]
     var isFloatShowing = false
+    var profileImg: UIImage?
 
     lazy var floatingDimView: UIView = {
         let view = UIView(frame: self.view.frame)
@@ -47,8 +48,13 @@ class MainViewController: UIViewController {
         super.viewDidLoad()
 
         addSearchBar()
-        addProfileIcon(user?.profileImage)
         updateDaily()
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        addProfileIcon(user?.profileImage)
     }
     
     func updateDaily(){
@@ -65,7 +71,9 @@ class MainViewController: UIViewController {
     @objc func reloadData(){
         meetingsToday = getToday(meetings: meetings)
         meetingsUpcoming = getUpcoming(meetings: meetings)
-        mainTableView.reloadData()
+        if mainTableView != nil{
+            mainTableView.reloadData()
+        }
     }
     
     
@@ -81,13 +89,23 @@ class MainViewController: UIViewController {
     
     func addProfileIcon(_ image: String?){
         let profileButton = UIButton(frame: CGRect(x: 0, y: -5, width: 40, height: 40))
-        let imageView = UIImageView()
-        if let image{
-            imageView.setImageFromStringURL(image)
+        profileButton.layer.cornerRadius = profileButton.frame.height / 2
+        profileButton.clipsToBounds = true
+        profileButton.contentMode = .scaleAspectFill
+        profileButton.setBackgroundImage(profileImg ?? UIImage(systemName: "pawprint.circle"), for: .normal)
+
+
+        if profileImg == nil, let str = user?.profileImage, let url = URL(string: str){
+            url.asyncImage { image in
+                DispatchQueue.main.async{
+                    profileButton.setBackgroundImage(image, for: .normal)
+                    self.profileImg = image?.resize(newWidth: 40)
+                }
+            }
         }
-        profileButton.setBackgroundImage(imageView.image ?? UIImage(systemName: "pawprint.circle"), for: .normal)
         profileButton.addTarget(self, action: #selector(toProfile), for: .touchUpInside)
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: profileButton)
+        
     }
     
     @objc func toProfile(){

--- a/Foodle/Foodle/ViewController/MainViewController.swift
+++ b/Foodle/Foodle/ViewController/MainViewController.swift
@@ -48,7 +48,24 @@ class MainViewController: UIViewController {
 
         addSearchBar()
         addProfileIcon(user?.profileImage)
-
+        updateDaily()
+    }
+    
+    func updateDaily(){
+        let calendar = Calendar.current
+        
+        let now = Date()
+        let date = calendar.date(bySettingHour: 00, minute: 00, second: 0, of: now)!
+        
+        let timer = Timer(fireAt: date, interval: 0, target: self, selector: #selector(reloadData), userInfo: nil, repeats: false)
+        
+        RunLoop.main.add(timer, forMode: RunLoop.Mode.common)
+    }
+    
+    @objc func reloadData(){
+        meetingsToday = getToday(meetings: meetings)
+        meetingsUpcoming = getUpcoming(meetings: meetings)
+        mainTableView.reloadData()
     }
     
     

--- a/Foodle/Foodle/ViewController/MainViewController.swift
+++ b/Foodle/Foodle/ViewController/MainViewController.swift
@@ -85,6 +85,8 @@ class MainViewController: UIViewController {
         search.searchBar.placeholder = ""
         search.searchBar.searchTextField.backgroundColor = .white
         search.searchBar.tintColor = .black
+        search.searchBar.searchTextField.autocorrectionType = .no
+        search.searchBar.searchTextField.spellCheckingType = .no
     }
     
     func addProfileIcon(_ image: String?){

--- a/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
+++ b/Foodle/Foodle/ViewController/MyPlaceScrollableViewController.swift
@@ -54,7 +54,7 @@ extension MyPlaceScrollableViewController: UITableViewDelegate, UITableViewDataS
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return dummyPlaceLists.count
+        return placeLists?.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -63,8 +63,9 @@ extension MyPlaceScrollableViewController: UITableViewDelegate, UITableViewDataS
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "MyPlaceTableViewCell") as! MyPlaceTableViewCell
-        cell.circleImageView.tintColor = UIColor(hexCode: dummyPlaceLists[indexPath.row].color, alpha: 1.0)
-        cell.listNameLabel.text = dummyPlaceLists[indexPath.row].name
+        guard let placeLists else { return cell }
+        cell.circleImageView.tintColor = UIColor(hexCode: placeLists[indexPath.row].color, alpha: 1.0)
+        cell.listNameLabel.text = placeLists[indexPath.row].name
         return cell
     }
     

--- a/Foodle/Foodle/ViewController/MyPlaceTableViewController.swift
+++ b/Foodle/Foodle/ViewController/MyPlaceTableViewController.swift
@@ -19,8 +19,8 @@ class MyPlaceTableViewController: UIViewController {
     }
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let vc = segue.destination as? DetailPlaceViewController{
-            if let placeIndex{
-                vc.place = dummyPlaceLists[placeListIndex!].places?[placeIndex]
+            if let placeIndex, let placeLists{
+                vc.place = placeLists[placeListIndex!].places?[placeIndex]
             }
         }
     }
@@ -41,7 +41,7 @@ extension MyPlaceTableViewController: UITableViewDataSource, UITableViewDelegate
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if let placeListIndex{
-            return dummyPlaceLists[placeListIndex].places?.count ?? 0
+            return placeLists?[placeListIndex].places?.count ?? 0
         }
         return 0
     }
@@ -53,7 +53,7 @@ extension MyPlaceTableViewController: UITableViewDataSource, UITableViewDelegate
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "resultTableViewCell") as! ResultTableViewcell
         if let placeListIndex{
-            if let target = dummyPlaceLists[placeListIndex].places?[indexPath.row]{
+            if let placeLists, let target = placeLists[placeListIndex].places?[indexPath.row]{
                 print(target)
                 cell.starButton.setImage(UIImage(systemName: "star.fill"), for: .normal)
                 cell.addressLabel.text = target.address

--- a/Foodle/Foodle/ViewController/ScrollableBottomSheetViewController.swift
+++ b/Foodle/Foodle/ViewController/ScrollableBottomSheetViewController.swift
@@ -3,7 +3,6 @@ import UIKit
 
 class ScrollableBottomSheetViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
-    
     var targetIndex: Int?
     
     @IBAction func addPlaceToList(_ sender: UIButton) {
@@ -14,7 +13,7 @@ class ScrollableBottomSheetViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let vc = segue.destination as? AddPlaceViewController{
             if let targetIndex{
-                vc.place = dummyPlaces[targetIndex]
+                vc.place = resultPlaces[targetIndex]
             }
         }
     }
@@ -39,7 +38,7 @@ extension ScrollableBottomSheetViewController: UITableViewDelegate, UITableViewD
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return dummyPlaces.count
+        return resultPlaces.count
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -48,7 +47,7 @@ extension ScrollableBottomSheetViewController: UITableViewDelegate, UITableViewD
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "resultTableViewCell") as! ResultTableViewcell
-        let target = dummyPlaces[indexPath.row]
+        let target = resultPlaces[indexPath.row]
         if target.getIsStarred(){
             cell.starButton.setImage(UIImage(systemName: "star.fill"), for: .normal)
         } else {

--- a/Foodle/Foodle/ViewController/SearchResultViewController.swift
+++ b/Foodle/Foodle/ViewController/SearchResultViewController.swift
@@ -7,9 +7,13 @@
 
 import UIKit
 
-class SearchResultViewController: UIViewController, UISearchControllerDelegate, UISearchBarDelegate {
+var resultPlaces = [Place]()
+var keyword = String()
+
+class SearchResultViewController: UIViewController{
 
     @IBOutlet weak var tableView: UITableView!
+
     
     func addSearchBar(){
         let search = UISearchController()
@@ -20,7 +24,9 @@ class SearchResultViewController: UIViewController, UISearchControllerDelegate, 
         search.searchBar.placeholder = ""
         search.searchBar.searchTextField.backgroundColor = .white
         search.searchBar.tintColor = .black
-        }
+        search.searchBar.searchTextField.autocorrectionType = .no
+        search.searchBar.searchTextField.spellCheckingType = .no
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,20 +42,34 @@ class SearchResultViewController: UIViewController, UISearchControllerDelegate, 
     }
     
 }
+extension SearchResultViewController: UISearchControllerDelegate, UISearchBarDelegate{
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        guard let text = searchBar.text else { return }
+        keyword = text + searchText
+        searchPlace(keyword) { result in
+            guard let result else { return }
+            resultPlaces = result
+            DispatchQueue.main.async{
+                self.tableView.reloadData()
+            }
+        }
+    }
+}
 
 extension SearchResultViewController: UITableViewDelegate, UITableViewDataSource{
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return dummyPlaces.count
+        return resultPlaces.count
     }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "searchResultCell", for: indexPath)
-        let target = dummyPlaces[indexPath.row]
+        let target = resultPlaces[indexPath.row]
         cell.textLabel?.text = target.placeName
         cell.detailTextLabel?.text = target.address
         
         return cell
     }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        resultPlaces.swapAt(0, indexPath.row)
         performSegue(withIdentifier: "toSearchView", sender: nil)
     }
     

--- a/Foodle/Foodle/ViewController/SearchViewController.swift
+++ b/Foodle/Foodle/ViewController/SearchViewController.swift
@@ -22,6 +22,9 @@ class SearchViewController: UIViewController {
         search.searchBar.placeholder = ""
         search.searchBar.searchTextField.backgroundColor = .white
         search.searchBar.tintColor = .black
+        search.searchBar.text = keyword
+        search.searchBar.searchTextField.autocorrectionType = .no
+        search.searchBar.searchTextField.spellCheckingType = .no
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -54,6 +57,7 @@ class SearchViewController: UIViewController {
     private func setResultView(){
         let bottomSheetVCSB = UIStoryboard(name: "Jinhee", bundle: nil)
         bottomSheetVC = bottomSheetVCSB.instantiateViewController(withIdentifier: "ScrollableBottomSheetViewController")
+        
         if let sheet = bottomSheetVC?.sheetPresentationController {
             let fraction = UISheetPresentationController.Detent.custom { context in
                 140


### PR DESCRIPTION
## 추가된 사항
- 장소 검색 기능을 구현했습니다만, 서버 문제로 아직 테스트는 하지 못하였습니다.
- 메인화면의 프로필 아이콘을 서버의 이미지를 띄울 수 있게 처리했습니다.
- 자정이 지날때마다 테이블뷰를 리로드하도록 처리했습니다.
- 마이플레이스와 관련된 뷰들의 정보를 서버 데이터를 띄우도록 처리했습니다.

## 추가적으로 작업해야 하는 부분
- 장소 검색 실제 작동 확인
- 마이플레이스와 관련된 부분으로 post할 부분 연동(리스트에서 플레이스 삭제, 리스트 자체 삭제)

## 화면
<img width="546" alt="image" src="https://github.com/user-attachments/assets/377e8c71-5eb5-40ae-b62f-9d0367015d92">
<img width="546" alt="image" src="https://github.com/user-attachments/assets/81d43d57-3052-4e30-b043-721d31ccfdd0">
<img width="546" alt="image" src="https://github.com/user-attachments/assets/4f198ecd-077c-4ae2-ba20-6b0c2cf7a599">
<img width="546" alt="image" src="https://github.com/user-attachments/assets/ee0dd807-3a65-43ab-a704-15782da391f0">

close #51 