### PR TITLE
[feat] 친구 상세, 일정 편집(친구) 뷰 서버와 연결

### DIFF
--- a/Foodle/Foodle/Base.lproj/Minjeong.storyboard
+++ b/Foodle/Foodle/Base.lproj/Minjeong.storyboard
@@ -587,7 +587,7 @@
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="금별맥주" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pKp-qt-15T">
-                                                    <rect key="frame" x="15" y="132.00000000000023" width="63" height="22"/>
+                                                    <rect key="frame" x="15" y="132" width="139" height="22"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                                     <nil key="textColor"/>

--- a/Foodle/Foodle/Cell/FriendsListViewCell.swift
+++ b/Foodle/Foodle/Cell/FriendsListViewCell.swift
@@ -142,6 +142,7 @@ extension FriendsListViewCell: UITableViewDelegate, UITableViewDataSource {
                let selectedFriend = sender as? Friend {
                 destinationVC.friendsNameText = selectedFriend.user.nickName
                 destinationVC.profileImgUrl = selectedFriend.user.profileImage
+                destinationVC.friendUid = selectedFriend.user.uid
             }
         }
     }

--- a/Foodle/Foodle/ViewController/EditMeetingViewController.swift
+++ b/Foodle/Foodle/ViewController/EditMeetingViewController.swift
@@ -33,8 +33,6 @@ class EditMeetingViewController: UIViewController, UICollectionViewDataSource, U
     }
     
     var scrollView: UIScrollView!
-    
-    var meeting = meetings
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -107,9 +105,9 @@ class EditMeetingViewController: UIViewController, UICollectionViewDataSource, U
     func addFriend(_ friend: Friend) {
         if let index = index {
             if self.section == 0 {
-                meetingsToday[index].joiners?.append(friend.user)
+                todayMeetings[index].joiners?.append(friend.user)
             } else if self.section == 1 {
-                meetingsUpcoming[collectionViewItem!].joiners?.append(friend.user)
+                upcomingMeetings[collectionViewItem!].joiners?.append(friend.user)
             }
         }
     }
@@ -117,9 +115,9 @@ class EditMeetingViewController: UIViewController, UICollectionViewDataSource, U
     func removeFriend(_ friend: Friend) {
         if let index = index {
             if self.section == 0 {
-                meetingsToday[index].joiners?.removeAll { $0.uid == friend.user.uid }
+                todayMeetings[index].joiners?.removeAll { $0.uid == friend.user.uid }
             } else if self.section == 1 {
-                meetingsUpcoming[collectionViewItem!].joiners?.removeAll { $0.uid == friend.user.uid }
+                upcomingMeetings[collectionViewItem!].joiners?.removeAll { $0.uid == friend.user.uid }
             }
         }
     }
@@ -127,9 +125,9 @@ class EditMeetingViewController: UIViewController, UICollectionViewDataSource, U
     func isSelected(_ friend: Friend) -> Bool {
         if let index = index {
             if self.section == 0 {
-                return meetingsToday[index].joiners?.contains(where: { $0.uid == friend.user.uid }) ?? false
+                return todayMeetings[index].joiners?.contains(where: { $0.uid == friend.user.uid }) ?? false
             } else if self.section == 1 {
-                return meetingsUpcoming[collectionViewItem!].joiners?.contains(where: { $0.uid == friend.user.uid }) ?? false
+                return upcomingMeetings[collectionViewItem!].joiners?.contains(where: { $0.uid == friend.user.uid }) ?? false
             }
         }
         return false
@@ -143,9 +141,9 @@ class EditMeetingViewController: UIViewController, UICollectionViewDataSource, U
         if collectionView == selectedName {
             if let index = index {
                 if self.section == 0 {
-                    return meetingsToday[index].joiners?.count ?? 0
+                    return todayMeetings[index].joiners?.count ?? 0
                 } else if self.section == 1 {
-                    return meetingsUpcoming[collectionViewItem!].joiners?.count ?? 0
+                    return upcomingMeetings[collectionViewItem!].joiners?.count ?? 0
                 }
             }
         }
@@ -159,9 +157,9 @@ class EditMeetingViewController: UIViewController, UICollectionViewDataSource, U
             var joiners: [User] = []
             
             if self.section == 0 {
-                joiners = meetingsToday[index!].joiners ?? []
+                joiners = todayMeetings[index!].joiners ?? []
             } else if self.section == 1 {
-                joiners = meetingsUpcoming[collectionViewItem!].joiners ?? []
+                joiners = upcomingMeetings[collectionViewItem!].joiners ?? []
             }
             
             let user = joiners[indexPath.item]
@@ -169,11 +167,10 @@ class EditMeetingViewController: UIViewController, UICollectionViewDataSource, U
             if let friend = Friends?.first(where: { $0.user.uid == user.uid }) {
                 cell.selectedName.text = friend.user.nickName
                 cell.onDeleteButtonTapped = { [weak self] in
-                    self?.removeFriend(friend)
-                    self?.selectedName.reloadData()
-                    self?.favTable.reloadData()
-                    self?.allTable.reloadData()
+                    self?.removeFriendByUID(friend.user.uid ?? "")
                 }
+            } else if user.uid == user.uid {
+                cell.selectedName.text = user.nickName
             }
             
             return cell


### PR DESCRIPTION
 ## 추가된 사항
- 친구 상세 뷰 서버와 연결
- 일정 편집(친구) 뷰 서버와 연결

## 추가해야 할 사항
- 일정 편집 후 서버로 넘기는 작업 필요(현재는 일정 상세 뷰에서 선택된 친구를 일정 편집 뷰로 연결하는 작업만 한 상태)

## 실행 화면
<img width="546" alt="image" src="https://github.com/user-attachments/assets/84024810-6335-4415-a95c-093145aacb22">
<img width="546" alt="image" src="https://github.com/user-attachments/assets/24bf256d-cf06-46f5-9aaa-4051116da241">
