### PR TITLE
[fix] 셀 레이아웃 수정

### DIFF
--- a/Foodle/Foodle/Base.lproj/Jinhee.storyboard
+++ b/Foodle/Foodle/Base.lproj/Jinhee.storyboard
@@ -689,7 +689,7 @@
                                                             <rect key="frame" x="0.0" y="0.0" width="256" height="193"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <subviews>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WZe-ZV-zSx">
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WZe-ZV-zSx">
                                                                     <rect key="frame" x="5" y="0.0" width="246" height="193"/>
                                                                     <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     <constraints>
@@ -907,7 +907,6 @@
                                                 </button>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6Jp-r3-j60">
                                                     <rect key="frame" x="313" y="50" width="70" height="70"/>
-                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="70" id="7cC-Fd-s1v"/>
                                                         <constraint firstAttribute="height" constant="70" id="qRv-D3-7th"/>
@@ -1370,7 +1369,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="393" height="218"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="sCo-eB-LeP">
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="sCo-eB-LeP">
                                                     <rect key="frame" x="10" y="5" width="373" height="208"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="seZ-vI-RDj">
@@ -1379,7 +1378,7 @@
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bqT-q2-Dk9">
                                                                     <rect key="frame" x="0.0" y="59" width="50" height="50"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="TpV-bn-HCP"/>
+                                                                        <constraint firstAttribute="width" constant="50" id="TpV-bn-HCP"/>
                                                                         <constraint firstAttribute="height" constant="50" id="cCa-tz-cXm"/>
                                                                     </constraints>
                                                                     <color key="tintColor" name="AccentColor"/>
@@ -1391,38 +1390,45 @@
                                                                 </button>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SeQ-Sz-ie9">
                                                                     <rect key="frame" x="303" y="49" width="70" height="70"/>
-                                                                    <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="70" id="caY-pA-t5b"/>
                                                                         <constraint firstAttribute="height" constant="70" id="orw-gB-ZOg"/>
                                                                     </constraints>
                                                                 </imageView>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UdH-bB-1F6">
-                                                                    <rect key="frame" x="55" y="20" width="238" height="128"/>
+                                                                    <rect key="frame" x="55" y="30" width="238" height="108"/>
                                                                     <subviews>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="라오빠빠" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pdU-NB-Gcf">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="72.666666666666671" height="25.333333333333332"/>
-                                                                            <constraints>
-                                                                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="200" id="NaO-wZ-gUI"/>
-                                                                            </constraints>
-                                                                            <fontDescription key="fontDescription" type="system" weight="black" pointSize="21"/>
-                                                                            <nil key="textColor"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
+                                                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="FNa-cP-d1U">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="238" height="25.333333333333332"/>
+                                                                            <subviews>
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="DAY ROW 데이로우" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pdU-NB-Gcf">
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="150.33333333333334" height="25.333333333333332"/>
+                                                                                    <fontDescription key="fontDescription" type="system" weight="black" pointSize="21"/>
+                                                                                    <nil key="textColor"/>
+                                                                                    <nil key="highlightedColor"/>
+                                                                                </label>
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="카페, 디저트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l2c-5w-PaU">
+                                                                                    <rect key="frame" x="155.33333333333334" y="0.0" width="82.666666666666657" height="25.333333333333332"/>
+                                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                                                    <nil key="highlightedColor"/>
+                                                                                </label>
+                                                                            </subviews>
+                                                                        </stackView>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="영업중" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TAA-8f-fo9">
-                                                                            <rect key="frame" x="0.0" y="30.333333333333336" width="44.333333333333336" height="20.333333333333336"/>
+                                                                            <rect key="frame" x="0.0" y="30.333333333333329" width="44.333333333333336" height="20.333333333333329"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                             <color key="textColor" name="AccentColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="920m" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LFt-ed-ll7">
-                                                                            <rect key="frame" x="0.0" y="107.66666666666666" width="45" height="20.333333333333329"/>
+                                                                            <rect key="frame" x="0.0" y="87.666666666666671" width="45" height="20.333333333333329"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" text="서울특별시 송파구 오금동 ㅇㅇㅇ륭ㅇㅇ" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3s-dA-fXI">
-                                                                            <rect key="frame" x="98" y="87.333333333333329" width="140" height="40.666666666666671"/>
+                                                                            <rect key="frame" x="98" y="67.333333333333329" width="140" height="40.666666666666671"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" constant="140" id="8RS-pH-cYz"/>
                                                                                 <constraint firstAttribute="height" relation="lessThanOrEqual" constant="42" id="W0p-xi-kqV"/>
@@ -1431,14 +1437,8 @@
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="카페" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l2c-5w-PaU">
-                                                                            <rect key="frame" x="82.666666666666657" y="2.6666666666666679" width="29.666666666666671" height="20.333333333333332"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                            <color key="textColor" systemColor="secondaryLabelColor"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="휴일 토, 일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zaw-9l-28n">
-                                                                            <rect key="frame" x="0.0" y="60.666666666666671" width="72.333333333333329" height="42"/>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="휴일 토, 일, 월, 화, 수, 목, 금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zaw-9l-28n">
+                                                                            <rect key="frame" x="0.0" y="60.666666666666671" width="93" height="22"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -1446,23 +1446,23 @@
                                                                     </subviews>
                                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     <constraints>
-                                                                        <constraint firstItem="l2c-5w-PaU" firstAttribute="centerY" secondItem="pdU-NB-Gcf" secondAttribute="centerY" id="39z-9h-q4m"/>
-                                                                        <constraint firstItem="l2c-5w-PaU" firstAttribute="leading" secondItem="pdU-NB-Gcf" secondAttribute="trailing" constant="10" id="3Bq-lX-qRx"/>
+                                                                        <constraint firstItem="FNa-cP-d1U" firstAttribute="leading" secondItem="TAA-8f-fo9" secondAttribute="leading" id="661-XD-FjH"/>
+                                                                        <constraint firstItem="FNa-cP-d1U" firstAttribute="width" secondItem="UdH-bB-1F6" secondAttribute="width" id="6l3-Ow-vw6"/>
+                                                                        <constraint firstAttribute="width" constant="360" id="7ep-Rf-NOa"/>
+                                                                        <constraint firstItem="FNa-cP-d1U" firstAttribute="leading" secondItem="UdH-bB-1F6" secondAttribute="leading" id="MRm-h8-q3T"/>
                                                                         <constraint firstItem="zaw-9l-28n" firstAttribute="top" secondItem="TAA-8f-fo9" secondAttribute="bottom" constant="10" id="PfH-ec-nCB"/>
                                                                         <constraint firstAttribute="bottom" secondItem="LFt-ed-ll7" secondAttribute="bottom" id="W4k-Ct-XKu"/>
                                                                         <constraint firstItem="TAA-8f-fo9" firstAttribute="leading" secondItem="LFt-ed-ll7" secondAttribute="leading" id="ZeT-iT-mA1"/>
-                                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="l2c-5w-PaU" secondAttribute="trailing" id="aSt-NQ-FjD"/>
-                                                                        <constraint firstAttribute="width" constant="360" id="cS4-eY-B9z"/>
+                                                                        <constraint firstItem="TAA-8f-fo9" firstAttribute="top" secondItem="FNa-cP-d1U" secondAttribute="bottom" constant="5" id="b2c-t4-qZv"/>
                                                                         <constraint firstItem="zaw-9l-28n" firstAttribute="top" relation="lessThanOrEqual" secondItem="TAA-8f-fo9" secondAttribute="bottom" constant="10" id="dJA-4y-j9R"/>
                                                                         <constraint firstItem="r3s-dA-fXI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="LFt-ed-ll7" secondAttribute="trailing" constant="5" id="fJa-dP-LLU"/>
                                                                         <constraint firstItem="LFt-ed-ll7" firstAttribute="leading" secondItem="UdH-bB-1F6" secondAttribute="leading" id="fXb-Uu-OXq"/>
                                                                         <constraint firstItem="zaw-9l-28n" firstAttribute="leading" secondItem="TAA-8f-fo9" secondAttribute="leading" id="gZA-sI-71C"/>
-                                                                        <constraint firstItem="pdU-NB-Gcf" firstAttribute="leading" secondItem="UdH-bB-1F6" secondAttribute="leading" id="laA-Xj-5N8"/>
+                                                                        <constraint firstItem="FNa-cP-d1U" firstAttribute="top" secondItem="UdH-bB-1F6" secondAttribute="top" id="kbO-bd-uvu"/>
+                                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="TAA-8f-fo9" secondAttribute="trailing" constant="20" symbolic="YES" id="leG-Nc-4vr"/>
                                                                         <constraint firstItem="LFt-ed-ll7" firstAttribute="top" secondItem="zaw-9l-28n" secondAttribute="bottom" constant="5" id="m3y-A4-Fmf"/>
                                                                         <constraint firstItem="LFt-ed-ll7" firstAttribute="baseline" secondItem="r3s-dA-fXI" secondAttribute="baseline" id="pzi-Re-Igb"/>
                                                                         <constraint firstAttribute="trailing" secondItem="r3s-dA-fXI" secondAttribute="trailing" id="q8c-4s-32f"/>
-                                                                        <constraint firstItem="TAA-8f-fo9" firstAttribute="top" secondItem="pdU-NB-Gcf" secondAttribute="bottom" constant="5" id="qW8-Pf-Ue4"/>
-                                                                        <constraint firstItem="pdU-NB-Gcf" firstAttribute="top" secondItem="UdH-bB-1F6" secondAttribute="top" id="uMc-wa-2YJ"/>
                                                                         <constraint firstItem="r3s-dA-fXI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="zaw-9l-28n" secondAttribute="trailing" constant="5" id="ze6-q9-qn6"/>
                                                                     </constraints>
                                                                 </view>
@@ -1470,8 +1470,8 @@
                                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                             <constraints>
                                                                 <constraint firstItem="UdH-bB-1F6" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="bqT-q2-Dk9" secondAttribute="trailing" constant="5" id="I6q-kP-EFt"/>
-                                                                <constraint firstAttribute="bottom" secondItem="UdH-bB-1F6" secondAttribute="bottom" constant="20" id="PuM-Z7-1Pv"/>
-                                                                <constraint firstItem="UdH-bB-1F6" firstAttribute="top" secondItem="seZ-vI-RDj" secondAttribute="top" constant="20" id="etd-HN-AxI"/>
+                                                                <constraint firstAttribute="bottom" secondItem="UdH-bB-1F6" secondAttribute="bottom" constant="30" id="PuM-Z7-1Pv"/>
+                                                                <constraint firstItem="UdH-bB-1F6" firstAttribute="top" secondItem="seZ-vI-RDj" secondAttribute="top" constant="30" id="etd-HN-AxI"/>
                                                                 <constraint firstItem="bqT-q2-Dk9" firstAttribute="centerY" secondItem="seZ-vI-RDj" secondAttribute="centerY" id="hbt-91-kFI"/>
                                                                 <constraint firstItem="bqT-q2-Dk9" firstAttribute="leading" secondItem="seZ-vI-RDj" secondAttribute="leading" id="pWb-4l-daF"/>
                                                                 <constraint firstItem="SeQ-Sz-ie9" firstAttribute="leading" secondItem="UdH-bB-1F6" secondAttribute="trailing" constant="10" id="paV-9t-rCh"/>
@@ -1480,7 +1480,7 @@
                                                             </constraints>
                                                         </view>
                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dgp-fU-04X">
-                                                            <rect key="frame" x="30" y="168" width="313" height="40"/>
+                                                            <rect key="frame" x="0.0" y="168" width="373" height="40"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="40" id="Yn3-5k-3hH"/>
                                                             </constraints>
@@ -1493,14 +1493,13 @@
                                                         </button>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstAttribute="trailing" secondItem="Dgp-fU-04X" secondAttribute="trailing" constant="30" id="GXs-nW-uBy"/>
-                                                        <constraint firstItem="Dgp-fU-04X" firstAttribute="leading" secondItem="sCo-eB-LeP" secondAttribute="leading" constant="30" id="vTE-1B-fNe"/>
+                                                        <constraint firstItem="seZ-vI-RDj" firstAttribute="leading" secondItem="sCo-eB-LeP" secondAttribute="leadingMargin" id="e8a-ac-MNS"/>
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="sCo-eB-LeP" secondAttribute="bottom" constant="5" id="23D-aJ-HLU"/>
                                                 <constraint firstItem="sCo-eB-LeP" firstAttribute="leading" secondItem="I4t-TQ-WHg" secondAttribute="leading" constant="10" id="AaN-zv-fuD"/>
+                                                <constraint firstAttribute="bottom" secondItem="Dgp-fU-04X" secondAttribute="bottom" constant="5" id="Aoj-cw-XuP"/>
                                                 <constraint firstItem="sCo-eB-LeP" firstAttribute="top" secondItem="I4t-TQ-WHg" secondAttribute="top" constant="5" id="QRE-uC-Pkc"/>
                                                 <constraint firstAttribute="trailing" secondItem="sCo-eB-LeP" secondAttribute="trailing" constant="10" id="Wi1-bT-EcS"/>
                                             </constraints>
@@ -1514,6 +1513,7 @@
                                             <outlet property="placeCategoryLabel" destination="l2c-5w-PaU" id="XLQ-Pj-LQS"/>
                                             <outlet property="placeImageView" destination="SeQ-Sz-ie9" id="zpR-MJ-exo"/>
                                             <outlet property="placeNameLabel" destination="pdU-NB-Gcf" id="27m-m2-y6e"/>
+                                            <outlet property="stackView" destination="sCo-eB-LeP" id="hz5-9w-lgu"/>
                                             <outlet property="starButton" destination="bqT-q2-Dk9" id="nCm-PH-KCy"/>
                                         </connections>
                                     </tableViewCell>

--- a/Foodle/Foodle/Cell/ResultTableViewcell.swift
+++ b/Foodle/Foodle/Cell/ResultTableViewcell.swift
@@ -18,6 +18,7 @@ class ResultTableViewcell: UITableViewCell {
     @IBOutlet weak var placeImageView: UIImageView!
     @IBOutlet weak var starButton: UIButton!
     @IBOutlet weak var addMeetingPlaceButton: UIButton!
+    @IBOutlet weak var stackView: UIStackView!
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -27,6 +28,10 @@ class ResultTableViewcell: UITableViewCell {
         super.setSelected(selected, animated: animated)
 
         // Configure the view for the selected state
+    }
+    
+    func hideButton(_ hide: Bool){
+        addMeetingPlaceButton.isHidden = hide
     }
     
 }

--- a/Foodle/Foodle/ViewController/ScrollableBottomSheetViewController.swift
+++ b/Foodle/Foodle/ViewController/ScrollableBottomSheetViewController.swift
@@ -62,6 +62,11 @@ extension ScrollableBottomSheetViewController: UITableViewDelegate, UITableViewD
         return resultPlaces.count
     }
     
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        guard newMeeting != nil else { return 170 }
+        return 218
+    }
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "resultTableViewCell") as! ResultTableViewcell
         let target = resultPlaces[indexPath.row]
@@ -71,9 +76,9 @@ extension ScrollableBottomSheetViewController: UITableViewDelegate, UITableViewD
             cell.starButton.setImage(UIImage(systemName: "star"), for: .normal)
         }
         if newMeeting != nil{
-            cell.addMeetingPlaceButton.isHidden = false
+            cell.hideButton(false)
         } else {
-            cell.addMeetingPlaceButton.isHidden = true
+            cell.hideButton(true)
         }
         cell.addressLabel.text = target.address
         cell.breakLabel.text = "휴일 " + target.close


### PR DESCRIPTION
## 수정된 사항
- 셀의 레이아웃이 추가된 버튼으로 인해 높이가 커지고, 레이아웃이 일정치 않아 깨지는 현상 발생

## 원인
- placeNameLabel과 category의 width제약을 주지 않아 발생 -> 스택뷰로 묶어 width constant를 가지고 있는 상위 뷰와 동일한 width를 가지도록 제약 추가
- 추가된 버튼이 hide되어도 셀의 높이가 변경되지 않기 때문에, newMeeting의 Nil여부에 따라 셀의 높이를 조정하도록 처리

## 실행 화면
- 서버 사용량 초과로 화면을 찍을 수 없음