### PR TITLE
[fix] 친구 목록 새로고침 수정

### DIFF
--- a/Foodle/Foodle/Cell/FriendsListViewCell.swift
+++ b/Foodle/Foodle/Cell/FriendsListViewCell.swift
@@ -130,9 +130,18 @@ class FriendsListViewCell: UIViewController {
                 print("Failed to add friend: Invalid response")
                 return
             }
-            
-            DispatchQueue.main.async {
-                self?.reloadTables()
+
+            fetchFriends(uid) { [weak self] friends in
+                DispatchQueue.main.async {
+                    self?.Friends = friends
+                    self?.reloadTables()
+                    
+                    let alert = UIAlertController(title: "", message: "성공적으로 추가되었습니다.", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                    self?.present(alert, animated: true, completion: nil)
+                    
+                    print(self?.Friends ?? "No friends")
+                }
             }
         }
         task.resume()

--- a/Foodle/Foodle/ViewController/LoginViewController.swift
+++ b/Foodle/Foodle/ViewController/LoginViewController.swift
@@ -15,15 +15,9 @@ class LoginViewController: UIViewController {
     @IBOutlet var loginLabel2: UILabel!
     @IBOutlet var kakaoButton: UIButton!
     @IBOutlet var naverButton: UIButton!
-    @IBOutlet var privacyLabel: UILabel!
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // PrivacyLabel에 밑줄 추가
-        let attributedString = NSMutableAttributedString(string: "개인정보 이용 처리 방침")
-        attributedString.addAttribute(NSAttributedString.Key.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: attributedString.length))
-        privacyLabel.attributedText = attributedString
         
         // '프들'만 볼드체로 변경
         if let labelText = loginLabel.text {

--- a/Foodle/Foodle/mul.lproj/Minjeong.xcstrings
+++ b/Foodle/Foodle/mul.lproj/Minjeong.xcstrings
@@ -445,18 +445,6 @@
         }
       }
     },
-    "F6u-4h-fWU.text" : {
-      "comment" : "Class = \"UILabel\"; text = \"개인정보 이용 처리 방침\"; ObjectID = \"F6u-4h-fWU\";",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "개인정보 이용 처리 방침"
-          }
-        }
-      }
-    },
     "FUH-Ke-RrB.text" : {
       "comment" : "Class = \"UILabel\"; text = \"1\"; ObjectID = \"FUH-Ke-RrB\";",
       "extractionState" : "extracted_with_value",


### PR DESCRIPTION
## 수정된 사항
- 친구 추가가 성공적으로 완료된 후 fetchFriends를 호출하여 Friends 배열을 업데이트하도록 변경
- 친구 추가 이후 추가 완료되었다는 알림 표시 추가

## 원인
- 친구 추가 이후 Friends 배열이 서버에서 데이터를 새로 받아오기 전에 UI를 갱신하려해 친구 목록이 새로고침되지 않는 문제
- friends가 아닌 Friends 배열을 업데이트 했어야 함